### PR TITLE
Improves validation against JUnit schema

### DIFF
--- a/cppcheck_junit.py
+++ b/cppcheck_junit.py
@@ -123,10 +123,13 @@ def generate_test_suite(errors):
     for file_name, errors in errors.items():
         test_case = ElementTree.SubElement(test_suite,
                                            'testcase',
-                                           name=os.path.relpath(file_name) if file_name else '')
+                                           name=os.path.relpath(file_name) if file_name else '',
+                                           classname='',
+                                           time=str(1))
         for error in errors:
             ElementTree.SubElement(test_case,
                                    'error',
+                                   type='',
                                    file=os.path.relpath(error.file) if error.file else '',
                                    line=str(error.line),
                                    message='{}: ({}) {}'.format(error.line,
@@ -149,7 +152,9 @@ def generate_single_success_test_suite():
     test_suite.attrib['time'] = str(1)
     ElementTree.SubElement(test_suite,
                            'testcase',
-                           name='Cppcheck success')
+                           name='Cppcheck success',
+                           classname='',
+                           time=str(1))
     return ElementTree.ElementTree(test_suite)
 
 

--- a/cppcheck_junit.py
+++ b/cppcheck_junit.py
@@ -8,6 +8,8 @@ import argparse
 import collections
 import os
 import sys
+from datetime import datetime
+from socket import gethostname
 from typing import Dict, List  # noqa: F401
 from xml.etree import ElementTree
 
@@ -110,10 +112,12 @@ def generate_test_suite(errors):
         XML test suite.
     """
     test_suite = ElementTree.Element('testsuite')
-    test_suite.attrib['errors'] = str(len(errors))
-    test_suite.attrib['failures'] = str(0)
     test_suite.attrib['name'] = 'Cppcheck errors'
+    test_suite.attrib['timestamp'] = datetime.isoformat(datetime.now())
+    test_suite.attrib['hostname'] = gethostname()
     test_suite.attrib['tests'] = str(len(errors))
+    test_suite.attrib['failures'] = str(0)
+    test_suite.attrib['errors'] = str(len(errors))
     test_suite.attrib['time'] = str(1)
 
     for file_name, errors in errors.items():
@@ -137,7 +141,12 @@ def generate_single_success_test_suite():
     """Generates a single successful JUnit XML testcase."""
     test_suite = ElementTree.Element('testsuite')
     test_suite.attrib['name'] = 'Cppcheck errors'
+    test_suite.attrib['timestamp'] = datetime.isoformat(datetime.now())
+    test_suite.attrib['hostname'] = gethostname()
     test_suite.attrib['tests'] = str(1)
+    test_suite.attrib['failures'] = str(0)
+    test_suite.attrib['errors'] = str(0)
+    test_suite.attrib['time'] = str(1)
     ElementTree.SubElement(test_suite,
                            'testcase',
                            name='Cppcheck success')

--- a/cppcheck_junit.py
+++ b/cppcheck_junit.py
@@ -7,8 +7,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import argparse
 import collections
 import os
-import sys
 from datetime import datetime
+import sys
 from socket import gethostname
 from typing import Dict, List  # noqa: F401
 from xml.etree import ElementTree

--- a/cppcheck_junit.py
+++ b/cppcheck_junit.py
@@ -6,10 +6,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import argparse
 import collections
-import os
 from datetime import datetime
-import sys
+import os
 from socket import gethostname
+import sys
 from typing import Dict, List  # noqa: F401
 from xml.etree import ElementTree
 

--- a/test.py
+++ b/test.py
@@ -106,7 +106,8 @@ class GenerateTestSuiteTestCase(unittest.TestCase):
     #   ref: https://raw.githubusercontent.com/windyroad/JUnit-Schema/master/JUnit.xsd
     # @TODO: Better thing to do here would be to curl or otherwise access the
     #        spec above instead of hardcoding pieces of it here
-    junit_testsuite_attributes = ['name', 'timestamp', 'hostname', 'tests', 'failures', 'errors', 'time']
+    junit_testsuite_attributes = ['name', 'timestamp', 'hostname', 'tests',
+                                  'failures', 'errors', 'time']
     junit_testcase_attributes = ['name', 'classname', 'time']
     junit_error_attributes = ['type']
 
@@ -190,7 +191,8 @@ class GenerateSingleSuccessTestSuite(unittest.TestCase):
     #   ref: https://raw.githubusercontent.com/windyroad/JUnit-Schema/master/JUnit.xsd
     # @TODO: Better thing to do here would be to curl or otherwise access the
     #        spec above instead of hardcoding pieces of it here
-    junit_testsuite_attributes = ['name', 'timestamp', 'hostname', 'tests', 'failures', 'errors', 'time']
+    junit_testsuite_attributes = ['name', 'timestamp', 'hostname', 'tests',
+                                  'failures', 'errors', 'time']
     junit_testcase_attributes = ['name', 'classname', 'time']
 
     def test(self):  # type: () -> None

--- a/test.py
+++ b/test.py
@@ -102,6 +102,14 @@ class ParseCppcheckTestCase(unittest.TestCase):
 
 
 class GenerateTestSuiteTestCase(unittest.TestCase):
+    # Expected attributes from JUnit XSD
+    #   ref: https://raw.githubusercontent.com/windyroad/JUnit-Schema/master/JUnit.xsd
+    # @TODO: Better thing to do here would be to curl or otherwise access the
+    #        spec above instead of hardcoding pieces of it here
+    junit_testsuite_attributes = ['name', 'timestamp', 'hostname', 'tests', 'failures', 'errors', 'time']
+    junit_testcase_attributes = ['name', 'classname', 'time']
+    junit_error_attributes = ['type']
+
     def test_single(self):  # type: () -> None
         errors = {'file_name':
                   [CppcheckError('file_name',
@@ -111,18 +119,27 @@ class GenerateTestSuiteTestCase(unittest.TestCase):
                                  'error_id',
                                  'verbose error message')]}
         tree = generate_test_suite(errors)
-        root = tree.getroot()
-        self.assertEqual(root.get('errors'), str(1))
-        self.assertEqual(root.get('failures'), str(0))
-        self.assertEqual(root.get('tests'), str(1))
+        testsuite_element = tree.getroot()
+        self.assertEqual(testsuite_element.get('errors'), str(1))
+        self.assertEqual(testsuite_element.get('failures'), str(0))
+        self.assertEqual(testsuite_element.get('tests'), str(1))
+        # Check that testsuite element is compliant with the spec
+        for required_attribute in self.junit_testsuite_attributes:
+            self.assertTrue(required_attribute in testsuite_element.attrib.keys())
 
-        test_case_element = root.find('testcase')
-        self.assertEqual(test_case_element.get('name'), 'file_name')
+        testcase_element = testsuite_element.find('testcase')
+        self.assertEqual(testcase_element.get('name'), 'file_name')
+        # Check that test_case is compliant with the spec
+        for required_attribute in self.junit_testcase_attributes:
+            self.assertTrue(required_attribute in testcase_element.attrib.keys())
 
-        error_element = test_case_element.find('error')
+        error_element = testcase_element.find('error')
         self.assertEqual(error_element.get('file'), 'file_name')
         self.assertEqual(error_element.get('line'), str(4))
         self.assertEqual(error_element.get('message'), '4: (severity) error message')
+        # Check that error element is compliant with the spec
+        for required_attribute in self.junit_error_attributes:
+            self.assertTrue(required_attribute in error_element.attrib.keys())
 
     def test_missing_file(self):  # type: () -> None
         errors = {'':
@@ -141,15 +158,21 @@ class GenerateTestSuiteTestCase(unittest.TestCase):
                                          'that may increase the checking time. For more details, '
                                          'use --enable=information.')]}
         tree = generate_test_suite(errors)
-        root = tree.getroot()
-        self.assertEqual(root.get('errors'), str(1))
-        self.assertEqual(root.get('failures'), str(0))
-        self.assertEqual(root.get('tests'), str(1))
+        testsuite_element = tree.getroot()
+        self.assertEqual(testsuite_element.get('errors'), str(1))
+        self.assertEqual(testsuite_element.get('failures'), str(0))
+        self.assertEqual(testsuite_element.get('tests'), str(1))
+        # Check that testsuite element is compliant with the spec
+        for required_attribute in self.junit_testsuite_attributes:
+            self.assertTrue(required_attribute in testsuite_element.attrib.keys())
 
-        test_case_element = root.find('testcase')
-        self.assertEqual(test_case_element.get('name'), '')
+        testcase_element = testsuite_element.find('testcase')
+        self.assertEqual(testcase_element.get('name'), '')
+        # Check that test_case is compliant with the spec
+        for required_attribute in self.junit_testcase_attributes:
+            self.assertTrue(required_attribute in testcase_element.attrib.keys())
 
-        error_element = test_case_element.find('error')
+        error_element = testcase_element.find('error')
         self.assertEqual(error_element.get('file'), '')
         self.assertEqual(error_element.get('line'), str(0))
         self.assertEqual(error_element.get('message'),
@@ -157,16 +180,34 @@ class GenerateTestSuiteTestCase(unittest.TestCase):
                          '12 configurations. Use --force to check all '
                          'configurations. For more details, use '
                          '--enable=information.')
+        # Check that error element is compliant with the spec
+        for required_attribute in self.junit_error_attributes:
+            self.assertTrue(required_attribute in error_element.attrib.keys())
 
 
 class GenerateSingleSuccessTestSuite(unittest.TestCase):
+    # Expected attributes from JUnit XSD
+    #   ref: https://raw.githubusercontent.com/windyroad/JUnit-Schema/master/JUnit.xsd
+    # @TODO: Better thing to do here would be to curl or otherwise access the
+    #        spec above instead of hardcoding pieces of it here
+    junit_testsuite_attributes = ['name', 'timestamp', 'hostname', 'tests', 'failures', 'errors', 'time']
+    junit_testcase_attributes = ['name', 'classname', 'time']
+
     def test(self):  # type: () -> None
         tree = generate_single_success_test_suite()
-        root = tree.getroot()
-        self.assertEqual(root.get('tests'), str(1))
+        testsuite_element = tree.getroot()
+        self.assertEqual(testsuite_element.get('tests'), str(1))
+        self.assertEqual(testsuite_element.get('errors'), str(0))
+        self.assertEqual(testsuite_element.get('failures'), str(0))
+        # Check that testsuite element is compliant with the spec
+        for required_attribute in self.junit_testsuite_attributes:
+            self.assertTrue(required_attribute in testsuite_element.attrib.keys())
 
-        test_case_element = root.find('testcase')
-        self.assertEqual(test_case_element.get('name'), 'Cppcheck success')
+        testcase_element = testsuite_element.find('testcase')
+        self.assertEqual(testcase_element.get('name'), 'Cppcheck success')
+        # Check that test_case is compliant with the spec
+        for required_attribute in self.junit_testcase_attributes:
+            self.assertTrue(required_attribute in testcase_element.attrib.keys())
 
 
 class ParseArgumentsTestCase(unittest.TestCase):


### PR DESCRIPTION
The two functions that generated JUnit XML were missing some required
attributes as defined by the JUnit schema:

https://raw.githubusercontent.com/windyroad/JUnit-Schema/master/JUnit.xsd

These missing attributes were messing with downstream tools that expected
those attributes to be present.

Also values for other XML attributes were improved by using standard Python
modules (datetime and socket).