### PR TITLE
Always set classname and name XML attributes for error test cases

### DIFF
--- a/cppcheck_junit.py
+++ b/cppcheck_junit.py
@@ -123,8 +123,9 @@ def generate_test_suite(errors):
     for file_name, errors in errors.items():
         test_case = ElementTree.SubElement(test_suite,
                                            'testcase',
-                                           name=os.path.relpath(file_name) if file_name else '',
-                                           classname='',
+                                           name=os.path.relpath(
+                                               file_name) if file_name else 'Cppcheck error',
+                                           classname='Cppcheck error',
                                            time=str(1))
         for error in errors:
             ElementTree.SubElement(test_case,
@@ -153,7 +154,7 @@ def generate_single_success_test_suite():
     ElementTree.SubElement(test_suite,
                            'testcase',
                            name='Cppcheck success',
-                           classname='',
+                           classname='Cppcheck success',
                            time=str(1))
     return ElementTree.ElementTree(test_suite)
 

--- a/test.py
+++ b/test.py
@@ -168,7 +168,7 @@ class GenerateTestSuiteTestCase(unittest.TestCase):
             self.assertTrue(required_attribute in testsuite_element.attrib.keys())
 
         testcase_element = testsuite_element.find('testcase')
-        self.assertEqual(testcase_element.get('name'), '')
+        self.assertEqual(testcase_element.get('name'), 'Cppcheck error')
         # Check that test_case is compliant with the spec
         for required_attribute in self.junit_testcase_attributes:
             self.assertTrue(required_attribute in testcase_element.attrib.keys())

--- a/test.py
+++ b/test.py
@@ -169,6 +169,7 @@ class GenerateTestSuiteTestCase(unittest.TestCase):
 
         testcase_element = testsuite_element.find('testcase')
         self.assertEqual(testcase_element.get('name'), 'Cppcheck error')
+        self.assertEqual(testcase_element.get('classname'), 'Cppcheck error')
         # Check that test_case is compliant with the spec
         for required_attribute in self.junit_testcase_attributes:
             self.assertTrue(required_attribute in testcase_element.attrib.keys())
@@ -207,6 +208,7 @@ class GenerateSingleSuccessTestSuite(unittest.TestCase):
 
         testcase_element = testsuite_element.find('testcase')
         self.assertEqual(testcase_element.get('name'), 'Cppcheck success')
+        self.assertEqual(testcase_element.get('classname'), 'Cppcheck success')
         # Check that test_case is compliant with the spec
         for required_attribute in self.junit_testcase_attributes:
             self.assertTrue(required_attribute in testcase_element.attrib.keys())


### PR DESCRIPTION
Fixes #5 