### PR TITLE
Updated junit report to recent format version

### DIFF
--- a/cppcheck_junit.py
+++ b/cppcheck_junit.py
@@ -123,8 +123,7 @@ def generate_test_suite(errors):
     for file_name, errors in errors.items():
         test_case = ElementTree.SubElement(test_suite,
                                            'testcase',
-                                           name=os.path.relpath(
-                                               file_name) if file_name else 'Cppcheck error',
+                                           name=os.path.relpath(file_name) if file_name else 'Cppcheck error',
                                            classname='Cppcheck error',
                                            time=str(1))
         for error in errors:
@@ -133,10 +132,11 @@ def generate_test_suite(errors):
             ElementTree.SubElement(test_case,
                                    'failure',
                                    type=error.error_id,
-                                   message=' [{}]: {}:{}\n{}'.format(error.severity,
-                                                                     path,
-                                                                     error.line,
-                                                                     msg))
+                                   message='[{}] {}: {}:{}'.format(error.severity,
+                                                                   error.error_id
+                                                                   path,
+                                                                   error.line),
+                                   verbose=msg)
 
     return ElementTree.ElementTree(test_suite)
 

--- a/cppcheck_junit.py
+++ b/cppcheck_junit.py
@@ -128,7 +128,7 @@ def generate_test_suite(errors):
                                            classname='Cppcheck error',
                                            time=str(1))
         for error in errors:
-            path = os.path.relpath(error.file) if error.file else '-'
+            path = error.file if error.file else '-'
             msg = error.verbose if error.verbose else error.msg
             ElementTree.SubElement(test_case,
                                    'failure',

--- a/cppcheck_junit.py
+++ b/cppcheck_junit.py
@@ -128,7 +128,7 @@ def generate_test_suite(errors):
                                            classname='Cppcheck error',
                                            time=str(1))
         for error in errors:
-            path = error.file if error.file else '-'
+            path = os.path.relpath(error.file) if error.file else '-'
             msg = error.verbose if error.verbose else error.msg
             ElementTree.SubElement(test_case,
                                    'failure',

--- a/cppcheck_junit.py
+++ b/cppcheck_junit.py
@@ -148,13 +148,11 @@ def generate_test_cases(errors):
                                            'testcase',
                                            id=error.file_with_line,
                                            name=error.file_with_line)
-        ElementTree.SubElement(test_case,
-                               'failure',
-                               type=error.id,
-                               message='[{}] {}: '.format(error.severity,
-                                                          error.id,
-                                                          error.file_with_line),
-                               verbose=error.message)
+        failure = ElementTree.SubElement(test_case,
+                                         'failure',
+                                         type=error.id,
+                                         message=error.message)
+        failure.text = '\n[{}] {}: {}\n{}\n'.format(error.severity, error.id, error.file_with_line, error.verbose)
     return ElementTree.ElementTree(root)
 
 

--- a/cppcheck_junit.py
+++ b/cppcheck_junit.py
@@ -133,7 +133,7 @@ def generate_test_suite(errors):
                                    'failure',
                                    type=error.error_id,
                                    message='[{}] {}: {}:{}'.format(error.severity,
-                                                                   error.error_id
+                                                                   error.error_id,
                                                                    path,
                                                                    error.line),
                                    verbose=msg)

--- a/cppcheck_junit.py
+++ b/cppcheck_junit.py
@@ -116,8 +116,8 @@ def generate_test_suite(errors):
     test_suite.attrib['timestamp'] = datetime.isoformat(datetime.now())
     test_suite.attrib['hostname'] = gethostname()
     test_suite.attrib['tests'] = str(len(errors))
-    test_suite.attrib['failures'] = str(0)
-    test_suite.attrib['errors'] = str(len(errors))
+    test_suite.attrib['failures'] = str(len(errors))
+    test_suite.attrib['errors'] = str(0)
     test_suite.attrib['time'] = str(1)
 
     for file_name, errors in errors.items():
@@ -128,14 +128,15 @@ def generate_test_suite(errors):
                                            classname='Cppcheck error',
                                            time=str(1))
         for error in errors:
+            path = os.path.relpath(error.file) if error.file else '-'
+            msg = error.verbose if error.verbose else error.msg
             ElementTree.SubElement(test_case,
-                                   'error',
-                                   type='',
-                                   file=os.path.relpath(error.file) if error.file else '',
-                                   line=str(error.line),
-                                   message='{}: ({}) {}'.format(error.line,
-                                                                error.severity,
-                                                                error.message))
+                                   'failure',
+                                   type=error.error_id,
+                                   message=' [{}]: {}:{}\n{}'.format(error.severity,
+                                                                     path,
+                                                                     error.line,
+                                                                     msg))
 
     return ElementTree.ElementTree(test_suite)
 


### PR DESCRIPTION
Hello

1. Changed section in testsuite and errors/failures count as errors section AFAIK is for tests which exited with error right now. Failures sections is for tests that failed using something like AssertEqual, etc. but exited correctly
2. Changed testcase element as no subelement 'error' exists right now, but 'failure'.


Consulted this:
https://raw.githubusercontent.com/windyroad/JUnit-Schema/master/JUnit.xsd