### PR TITLE
Include error info from multiple locations

### DIFF
--- a/cppcheck_junit.py
+++ b/cppcheck_junit.py
@@ -4,6 +4,7 @@
 
 import argparse
 import collections
+from dataclasses import dataclass
 from datetime import datetime
 import os
 from socket import gethostname
@@ -14,48 +15,38 @@ from xml.etree import ElementTree
 from exitstatus import ExitStatus
 
 
+@dataclass
 class CppcheckLocation:
-    def __init__(self, file: str, line: int, column: int, info: str) -> None:
-        """Constructor.
-        Args:
-            file: Error location file.
-            line: Error location line.
-            column: Error location column.
-            info: Error location info.
-        """
+    """
+    file: Error location file.
+    line: Error location line.
+    column: Error location column.
+    info: Error location info.
+    """
 
-        self.file = file
-        self.line = line
-        self.column = column
-        self.info = info
+    file: str
+    line: int
+    column: int
+    info: str
 
 
+@dataclass
 class CppcheckError:
-    def __init__(
-        self,
-        file: str,
-        locations: [CppcheckLocation],
-        message: str,
-        severity: str,
-        error_id: str,
-        verbose: str,
-    ) -> None:
-        """Constructor.
+    """
+    file: File error originated on.
+    locations: Error locations.
+    message: Error message.
+    severity: Severity of the error.
+    error_id: Unique identifier for the error.
+    verbose: Verbose error message.
+    """
 
-        Args:
-            file: File error originated on.
-            locations: Error locations.
-            message: Error message.
-            severity: Severity of the error.
-            error_id: Unique identifier for the error.
-            verbose: Verbose error message.
-        """
-        self.file = file
-        self.locations = locations
-        self.message = message
-        self.severity = severity
-        self.error_id = error_id
-        self.verbose = verbose
+    file: str
+    locations: List[CppcheckLocation]
+    message: str
+    severity: str
+    error_id: str
+    verbose: str
 
 
 def parse_arguments() -> argparse.Namespace:


### PR DESCRIPTION
```cpp
void f()
{
    int err = -ENOMEM;
    err = dostuff();
}
```

`cppcheck` on this bit adds a `redundantInitialization` `error` which has multiple `location` elements.
```xml
<results version="2">
<cppcheck version="2.13.0"/>
<errors>
<error id="redundantInitialization" severity="style" msg="Redundant initialization for 'err'. The initialized value is overwritten before it is read." verbose="Redundant initialization for 'err'. The initialized value is overwritten before it is read." cwe="563" file0="tests/bad.cpp">
<location file="tests/bad.cpp" line="4" column="9" info="err is overwritten"/>
<location file="tests/bad.cpp" line="3" column="13" info="err is initialized"/>
<symbol>err</symbol>
</error>
<error id="unreadVariable" severity="style" msg="Variable 'err' is assigned a value that is never used." verbose="Variable 'err' is assigned a value that is never used." cwe="563" file0="tests/bad.cpp">
<location file="tests/bad.cpp" line="4" column="9"/>
<symbol>err</symbol>
</error>
<error id="unusedFunction" severity="style" msg="The function 'f' is never used." verbose="The function 'f' is never used." cwe="561">
<location file="tests/bad.cpp" line="1" column="0"/>
<symbol>f</symbol>
</error>
<error id="checkersReport" severity="information" msg="Active checkers: 161/592 (use --checkers-report=<filename> to see details)" verbose="Active checkers: 161/592 (use --checkers-report=<filename> to see details)"/>
</errors>
</results>
```
This PR makes several changes (as in the comments) to accommodate this info.

```xml
<testsuite name="Cppcheck errors" timestamp="2024-01-06T12:17:52.604468" hostname="dbn" tests="2" failures="0" errors="2" time="1">
<testcase name="tests/bad.cpp" classname="Cppcheck error" time="1">
<error type="style" file="tests/bad.cpp" message="Redundant initialization for 'err'. The initialized value is overwritten before it is read.">
Redundant initialization for 'err'. The initialized value is overwritten before it is read.
tests/bad.cpp:4:9: err is overwritten
tests/bad.cpp:3:13: err is initialized
</error>
<error type="style" file="tests/bad.cpp" message="Variable 'err' is assigned a value that is never used.">
tests/bad.cpp:4:9: Variable 'err' is assigned a value that is never used.
</error>
<error type="style" file="tests/bad.cpp" message="The function 'f' is never used.">tests/bad.cpp:1:0: The function 'f' is never used.</error>
</testcase>
<testcase name="Cppcheck error" classname="Cppcheck error" time="1">
<error type="information" file="" message="Active checkers: 161/592 (use --checkers-report=<filename> to see details)">
Active checkers: 161/592 (use --checkers-report=<filename> to see details)
</error>
</testcase>
</testsuite>
```